### PR TITLE
Extended the CI with Mac OS support, from-scratch builds and code alerts by dscanner

### DIFF
--- a/.github/qa/fix_clippy_sarif.py
+++ b/.github/qa/fix_clippy_sarif.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import argparse
+
+
+def setup() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fix the paths of a SARIF JSON file")
+    parser.add_argument("file", help="in file (SARIF JSON)")
+    parser.add_argument("--base", help="base path for the source code locations", metavar="dir", required=True)
+    return parser
+
+
+def main(args: argparse.Namespace) -> int:
+    with open(args.file) as f:
+        data = json.load(f)
+
+    for run in data["runs"]:
+        for result in run["results"]:
+            for location in result["locations"]:
+                p = location["physicalLocation"]["artifactLocation"]["uri"]
+                p = os.path.join(args.base, os.path.normpath(p))
+                location["physicalLocation"]["artifactLocation"]["uri"] = p
+
+    with open(args.file, "w") as f:
+        json.dump(data, f, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    argv = setup().parse_args()
+    exit(main(argv))

--- a/.github/qa/sonar_to_sarif.py
+++ b/.github/qa/sonar_to_sarif.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+import argparse
+import subprocess
+
+
+SCHEMA_URL = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
+
+
+def to_level(severity: str) -> str:
+    return {"MINOR": "note", "MAJOR": "warning"}.get(severity, "warning")
+
+
+def setup() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Convert sonarQubeGenericIssueData JSON file into SARIF JSON file")
+    parser.add_argument("-i", "--in-file", help="in file (sonarQubeGenericIssueData JSON)", metavar="f", required=True)
+    parser.add_argument("-o", "--out-file", help="out file (SARIF JSON)", metavar="f", required=True)
+    parser.add_argument("-f", "--force", action="store_true", help="allow overwriting files")
+    parser.add_argument("--base", help="base path for the source code locations", metavar="dir")
+    parser.add_argument("--git", help="git repository to add extra revision info to SARIF output", metavar="repo")
+    return parser
+
+
+def main(args: argparse.Namespace) -> int:
+    if os.path.exists(args.out_file) and not args.force:
+        print(f"Output file {args.out_file!r} already exists. Use '-f' to overwrite it.", file=sys.stderr)
+        return 1
+    with open(args.in_file) as f:
+        content = json.load(f)
+
+    results = []
+    counter = 0
+    for issue in content["issues"]:
+        p = os.path.normpath(issue["primaryLocation"]["filePath"])
+        if args.base:
+            p = os.path.join(args.base, p)
+        results.append({
+            "ruleId": issue["ruleId"],
+            "level": to_level(issue["severity"]),
+            "message": {
+                "text": issue["primaryLocation"]["message"]
+            },
+            "locations": [{
+                "id": counter,
+                "physicalLocation": {
+                    "artifactLocation": {
+                        "uri": p
+                    },
+                    "region": {
+                        "startLine": issue["primaryLocation"]["textRange"]["startLine"]
+                    }
+                }
+            }]
+        })
+        counter += 1
+
+    scanner_version = subprocess.run(
+        ["dub", "run", "dscanner", "--", "--version"],
+        capture_output=True
+    ).stdout.strip().decode("UTF-8").split("\n")[-1]
+    run = {
+        "tool": {
+            "driver": {
+                 "name": "dscanner",
+                 "version": scanner_version,
+                 "semanticVersion": scanner_version[1:]
+             }
+        },
+        "conversion": {
+            "tool": {
+                "driver": {
+                    "name": "sonar2sarif.py"
+                }
+            },
+            "invocation": {
+                "commandLine": "python3 " + " ".join(sys.argv),
+                "executionSuccessful": True
+            }
+        },
+        "results": results
+    }
+    if args.git:
+        commit_sha = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True).stdout.strip()
+        branch = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True).stdout.strip()
+        version_info = {
+            "repositoryUri": args.git,
+            "revisionId": commit_sha.decode("UTF-8"),
+            "branch": branch.decode("UTF-8")
+        }
+        run["versionControlProvenance"] = [version_info]
+
+    data = {"version": "2.1.0", "runs": [run], "$schema": SCHEMA_URL}
+    with open(args.out_file, "w") as f:
+        json.dump(data, f, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    argv = setup().parse_args()
+    exit(main(argv))

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -139,14 +139,15 @@ jobs:
         run: |
           export PATH=~/.cargo/bin:$PATH
           export CARGO_TARGET_DIR=~/cache/${GITHUB_REPOSITORY}/rorm/target
-          cargo clippy -F tokio-rustls --message-format=json | clippy-sarif | tee ../rust-clippy-results.sarif | sarif-fmt
+          cargo clippy --workspace --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+          python3 ../.github/qa/fix_clippy_sarif.py --base rorm rust-clippy-results.sarif
         continue-on-error: true
         working-directory: rorm
 
-      - name: Upload analysis results to GitHub
+      - name: Upload clippy analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: rust-clippy-results.sarif
+          sarif_file: rorm/rust-clippy-results.sarif
           wait-for-processing: true
 
   dub-test-linux:
@@ -155,12 +156,6 @@ jobs:
     runs-on: [ self-hosted, linux, x64 ]
     steps:
       - uses: actions/checkout@v3
-
-      - name: Linting
-        run: dub lint || echo FAIL
-        env:
-          DLFAGS: "-lowmem"
-        working-directory: ./dorm
 
       - name: Build rorm-lib (release)
         run: |
@@ -175,6 +170,21 @@ jobs:
         env:
           DFLAGS: "-lowmem"
         working-directory: ./dorm
+
+      - name: Lint dorm with dscanner
+        run: |
+          dub run dscanner -- --report --reportFile=report.json --reportFormat=sonarQubeGenericIssueData
+          wc -l report.json
+          python3 ../.github/qa/sonar_to_sarif.py -i report.json -o report.sarif --base dorm --git ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+        env:
+          DLFAGS: "-lowmem"
+        working-directory: ./dorm
+
+      - name: Upload dscanner analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: dorm/report.sarif
+          wait-for-processing: true
 
   integration-test-linux:
     name: Integration Test
@@ -214,6 +224,9 @@ jobs:
             health_cmd: "mysqladmin ping"
             config: mysql.toml
           - image: mariadb:10.8
+            health_cmd: "mysqladmin ping"
+            config: mysql.toml
+          - image: mariadb:10.7
             health_cmd: "mysqladmin ping"
             config: mysql.toml
           - image: mariadb:10.6

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,8 +6,56 @@ on:
       - docs
   pull_request:
 
-# This CI configuration makes heavy use of the local cache of a self-hosted Linux runner
+# This CI configuration makes heavy use of the local cache of a self-hosted Linux runner, except for the first job
 jobs:
+  build-linux-shared:
+    name: Build rorm from scratch
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-Cinstrument-coverage"
+      LLVM_PROFILE_FILE: "coverage-rorm_%p-%m.profraw"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update rust
+        run: rustup update
+
+      - name: Install rorm-cli (release)
+        run: |
+          rustup component add clippy
+          cargo install clippy-sarif sarif-fmt
+          cargo install rorm-cli --path ./rorm/rorm-cli -f
+
+      - name: Build and test
+        run: |
+          set -x
+          cargo build -p rorm-lib
+          cargo test -p rorm-cli
+          cargo test -p rorm-db -F tokio-rustls
+          cargo test -p rorm-declaration
+          cargo test -p rorm-lib
+          cargo test -p rorm-macro
+          cargo test -p rorm-sql -F sqlite
+          cargo test -p rorm-sql -F mysql
+          cargo test -p rorm-sql -F postgres
+          cargo test -F tokio-rustls
+        working-directory: ./rorm
+
+      - name: Execute rorm-sample with SQLite
+        env:
+          CONFIG_FILE: "sqlite.toml"
+        run: |
+          set -x
+          RUST_BACKTRACE=full cargo run -- --help
+          echo Config: ${CONFIG_FILE}
+          rm -rvf .models.json
+          rorm-cli migrate --database-config "${CONFIG_FILE}" --log-sql
+          cargo run -F rorm-main
+          rorm-cli make-migrations
+          rorm-cli migrate --database-config "${CONFIG_FILE}" --log-sql
+          RUST_BACKTRACE=full RUST_LOG=rorm=debug cargo run -- "${CONFIG_FILE}"
+        working-directory: ./rorm/rorm-sample
+
   build-linux:
     name: Build rorm
     runs-on: [ self-hosted, linux, x64 ]
@@ -50,7 +98,6 @@ jobs:
           export CARGO_TARGET_DIR=~/cache/${GITHUB_REPOSITORY}/rorm/target
           set -e
           set -x
-          cargo build -F tokio-rustls
           cargo test -p rorm-cli
           cargo test -p rorm-db -F tokio-rustls
           cargo test -p rorm-declaration

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,7 +29,6 @@ jobs:
         run: |
           set -x
           cargo build -p rorm-lib
-          cargo build -p rorm-lib -r
           cargo test -p rorm-cli
           cargo test -p rorm-db -F tokio-rustls
           cargo test -p rorm-declaration
@@ -40,12 +39,6 @@ jobs:
           cargo test -p rorm-sql -F postgres
           cargo test -F tokio-rustls
         working-directory: ./rorm
-
-      - name: Build rorm-sample
-        run: |
-          cargo build
-          cargo build -r
-        working-directory: ./rorm/rorm-sample
 
       - name: Execute rorm-sample with SQLite
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,63 @@
+name: Build & Test for MacOS
+on:
+  push:
+    paths-ignore:
+      - "*.md"
+      - docs
+  pull_request:
+
+jobs:
+  build-macos-shared:
+    name: Build rorm from scratch
+    runs-on: macos-latest
+    env:
+      RUSTFLAGS: "-Cinstrument-coverage"
+      LLVM_PROFILE_FILE: "coverage-rorm_%p-%m.profraw"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update rust
+        run: rustup update
+
+      - name: Install rorm-cli (release)
+        run: |
+          rustup component add clippy
+          cargo install clippy-sarif sarif-fmt
+          cargo install rorm-cli --path ./rorm/rorm-cli -f
+
+      - name: Build and test
+        run: |
+          set -x
+          cargo build -p rorm-lib
+          cargo build -p rorm-lib -r
+          cargo test -p rorm-cli
+          cargo test -p rorm-db -F tokio-rustls
+          cargo test -p rorm-declaration
+          cargo test -p rorm-lib
+          cargo test -p rorm-macro
+          cargo test -p rorm-sql -F sqlite
+          cargo test -p rorm-sql -F mysql
+          cargo test -p rorm-sql -F postgres
+          cargo test -F tokio-rustls
+        working-directory: ./rorm
+
+      - name: Build rorm-sample
+        run: |
+          cargo build
+          cargo build -r
+        working-directory: ./rorm/rorm-sample
+
+      - name: Execute rorm-sample with SQLite
+        env:
+          CONFIG_FILE: "sqlite.toml"
+        run: |
+          set -x
+          RUST_BACKTRACE=full cargo run -- --help
+          echo Config: ${CONFIG_FILE}
+          rm -rvf .models.json
+          rorm-cli migrate --database-config "${CONFIG_FILE}" --log-sql
+          cargo run -F rorm-main
+          rorm-cli make-migrations
+          rorm-cli migrate --database-config "${CONFIG_FILE}" --log-sql
+          RUST_BACKTRACE=full RUST_LOG=rorm=debug cargo run -- "${CONFIG_FILE}"
+        working-directory: ./rorm/rorm-sample

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,30 +77,30 @@ jobs:
           RUST_BACKTRACE=full RUST_LOG=rorm=debug cargo run -- "${CONFIG_FILE}"
 
   build-windows:
-    name: Build rorm (stable)
+    name: Build rorm
     runs-on: [ self-hosted, windows, x64 ]
     steps:
       - uses: actions/checkout@v3
 
       - name: Build rorm-lib
         run: |
-          export CARGO_TARGET_DIR=~/actions/cache/stable/${GITHUB_REPOSITORY}/rorm/target
+          export CARGO_TARGET_DIR=~/cache/${GITHUB_REPOSITORY}/rorm/target
           ~/.cargo/bin/cargo build -p rorm-lib
           ~/.cargo/bin/cargo build -p rorm-lib -r
         working-directory: ./rorm
 
       - name: Install rorm-cli (release)
-        run: CARGO_TARGET_DIR=~/actions/cache/stable/${GITHUB_REPOSITORY}/rorm/target ~/.cargo/bin/cargo install rorm-cli --path ./rorm/rorm-cli
+        run: CARGO_TARGET_DIR=~/cache/${GITHUB_REPOSITORY}/rorm/target ~/.cargo/bin/cargo install rorm-cli --path ./rorm/rorm-cli
 
       - name: Build rorm-sample
         run: |
-          export CARGO_TARGET_DIR=~/actions/cache/stable/${GITHUB_REPOSITORY}/rorm/target
+          export CARGO_TARGET_DIR=~/cache/${GITHUB_REPOSITORY}/rorm/target
           ~/.cargo/bin/cargo build
           ~/.cargo/bin/cargo build -r
         working-directory: ./rorm/rorm-sample
 
   cargo-test-windows:
-    name: Cargo Tests (stable)
+    name: Cargo Tests
     needs: build-windows
     env:
       RUSTFLAGS: "-Cinstrument-coverage"
@@ -115,23 +115,25 @@ jobs:
       - name: Run tests
         run: |
           export PATH=~/.cargo/bin:$PATH
-          export CARGO_TARGET_DIR=~/actions/cache/stable/${GITHUB_REPOSITORY}/rorm/target
+          export CARGO_TARGET_DIR=~/cache/${GITHUB_REPOSITORY}/rorm/target
           set -e
           set -x
-          cargo build -F tokio-rustls
           cargo test -p rorm-cli
           cargo test -p rorm-db -F tokio-rustls
           cargo test -p rorm-declaration
           cargo test -p rorm-lib
           cargo test -p rorm-macro
-          # TODO: This is currently not supported and results in linker errors (LNK1181)
-          # cargo test -p rorm-sql -F sqlite
+          cp -v ~/sqlite3.lib ./
+          cp -v ~/sqlite3.lib rorm-sql/
+          cargo test -p rorm-sql -F sqlite
+          cargo test -p rorm-sql -F mysql
+          cargo test -p rorm-sql -F postgres
           cargo test -F tokio-rustls
         working-directory: ./rorm
 
       - name: Create code coverage report
         run: |
-          export CARGO_TARGET_DIR=~/actions/cache/stable/${GITHUB_REPOSITORY}/rorm/target
+          export CARGO_TARGET_DIR=~/cache/${GITHUB_REPOSITORY}/rorm/target
           ~/.cargo/bin/grcov . --binary-path $CARGO_TARGET_DIR/debug -s . -t html --branch --ignore-not-existing -o ./coverage
           cp -rv coverage-rorm*raw ./coverage
         working-directory: ./rorm
@@ -140,36 +142,6 @@ jobs:
         with:
           name: coverage-report
           path: rorm/coverage
-
-  clippy-analyze-windows:
-    name: Clippy Analyze
-    needs: build-windows
-    runs-on: [ self-hosted, windows, x64 ]
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup utilities
-        run: |
-          ~/.cargo/bin/rustup component add clippy
-          ~/.cargo/bin/cargo install clippy-sarif sarif-fmt
-
-      - name: Run rust-clippy
-        run: |
-          export PATH=~/.cargo/bin:$PATH
-          export CARGO_TARGET_DIR=~/actions/cache/nightly/${GITHUB_REPOSITORY}/rorm/target
-          cargo clippy -F tokio-rustls --message-format=json | clippy-sarif | tee ../rust-clippy-results.sarif | sarif-fmt
-        continue-on-error: true
-        working-directory: rorm
-
-      - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: rust-clippy-results.sarif
-          wait-for-processing: true
 
   dub-test-windows:
     name: Dub Test
@@ -186,7 +158,7 @@ jobs:
 
       - name: Build rorm-lib (release)
         run: |
-          export CARGO_TARGET_DIR=~/actions/cache/stable/${GITHUB_REPOSITORY}/rorm/target
+          export CARGO_TARGET_DIR=~/cache/${GITHUB_REPOSITORY}/rorm/target
           ~/.cargo/bin/cargo build -p rorm-lib -r
           mkdir -pv target/release/
           cp -v ${CARGO_TARGET_DIR}/release/rorm.lib target/release/
@@ -207,7 +179,7 @@ jobs:
 
       - name: Build rorm-lib (release)
         run: |
-          export CARGO_TARGET_DIR=~/actions/cache/stable/${GITHUB_REPOSITORY}/rorm/target
+          export CARGO_TARGET_DIR=~/cache/${GITHUB_REPOSITORY}/rorm/target
           ~/.cargo/bin/cargo build -p rorm-lib -r
           mkdir -pv target/release/
           cp -v ${CARGO_TARGET_DIR}/release/rorm.lib target/release/
@@ -219,7 +191,7 @@ jobs:
         run: |
           set -x
           export PATH=~/.cargo/bin:$PATH
-          export CARGO_TARGET_DIR=~/actions/cache/stable/${GITHUB_REPOSITORY}/rorm/target
+          export CARGO_TARGET_DIR=~/cache/${GITHUB_REPOSITORY}/rorm/target
           ./run.sh
         working-directory: ./dorm/integration-tests/
 
@@ -239,19 +211,19 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run the sample help
-        run: CARGO_TARGET_DIR=~/actions/cache/stable/${GITHUB_REPOSITORY}/rorm/target RUST_BACKTRACE=full ~/.cargo/bin/cargo run -- --help
+        run: CARGO_TARGET_DIR=~/cache/${GITHUB_REPOSITORY}/rorm/target RUST_BACKTRACE=full ~/.cargo/bin/cargo run -- --help
         working-directory: ./rorm/rorm-sample
 
       - name: Run the project for ${{ matrix.config }}
         run: |
           set -x
-          export CARGO_TARGET_DIR=~/actions/cache/stable/${GITHUB_REPOSITORY}/rorm/target
+          export CARGO_TARGET_DIR=~/cache/${GITHUB_REPOSITORY}/rorm/target
           echo Config: ${{ matrix.config }}
           echo "DROP DATABASE db; CREATE DATABASE db;" | "C:\\Program Files\\MariaDB 10.6\\bin\\mysql.exe" -uroot -proot mysql
           echo "DROP DATABASE db; CREATE DATABASE db; ALTER DATABASE db OWNER TO username; GRANT ALL PRIVILEGES ON DATABASE db TO username;" | PGPASSWORD=postgres "C:\\Program Files\\PostgreSQL\\15\\bin\\psql.exe" -e -w -hlocalhost -Upostgres postgres
           rm -rvf .models.json
           ~/.cargo/bin/rorm-cli migrate --database-config "${{ matrix.config }}" --log-sql
-          ~/.cargo/bin/cargo run -F rorm-main
+          ~/.cargo/bin/cargo run -F rorm-main --quiet
           ~/.cargo/bin/rorm-cli make-migrations
           ~/.cargo/bin/rorm-cli migrate --database-config "${{ matrix.config }}" --log-sql
           RUST_BACKTRACE=full RUST_LOG=rorm=debug ~/.cargo/bin/cargo run -- "${{ matrix.config }}"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,9 +11,71 @@ defaults:
   run:
     shell: sh
 
-# This CI configuration makes heavy use of the local cache of a self-hosted Windows runner
+# This CI configuration makes heavy use of the local cache of a self-hosted Windows runner, except for the first job
 # Due to eval restrictions in the GitHub workflow configuration, the CARGO_TARGET_DIR must be set for every single step
 jobs:
+  build-windows-shared:
+    name: Build rorm from scratch
+    runs-on: windows-latest
+    env:
+      RUSTFLAGS: "-Cinstrument-coverage"
+      LLVM_PROFILE_FILE: "coverage-rorm_%p-%m.profraw"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download the SQLite3 lib files
+        run: |
+          set -x
+          curl https://sqlite.org/2022/sqlite-amalgamation-3400000.zip -O
+          unzip sqlite-amalgamation-3400000.zip
+          mv sqlite-amalgamation-3400000 sqlite-dev
+          rm -v sqlite-amalgamation-3400000.zip
+          curl https://sqlite.org/2022/sqlite-dll-win64-x64-3400000.zip -O
+          unzip sqlite-dll-win64-x64-3400000.zip
+          mv sqlite3.def sqlite3.dll sqlite-dev
+          rm -v sqlite-dll-win64-x64-3400000.zip
+
+      - name: Build the SQLite3 library
+        shell: cmd
+        run: |
+          cd sqlite-dev
+          dir
+          set VSCMD_DEBUG=1
+          "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\Tools\\VsDevCmd.bat" & dir && lib /DEF:sqlite3.def /OUT:sqlite3.lib /MACHINE:x64 & dir
+
+      - name: Update rust, install utilities, build & test
+        env:
+          CONFIG_FILE: "sqlite.toml"
+        run: |
+          set -x
+          cp -v sqlite-dev/sqlite3.lib rorm
+          cp -v sqlite-dev/sqlite3.lib rorm/rorm-sql
+          rustup update
+          rustup component add clippy
+          cargo install clippy-sarif sarif-fmt
+          cargo install rorm-cli --path ./rorm/rorm-cli -f
+          cd rorm
+          cargo build -p rorm-lib
+          cargo test -p rorm-cli
+          cargo test -p rorm-db -F tokio-rustls
+          cargo test -p rorm-declaration
+          cargo test -p rorm-lib
+          cargo test -p rorm-macro
+          ls -lah rorm-sql
+          cargo test -p rorm-sql -F sqlite
+          cargo test -p rorm-sql -F mysql
+          cargo test -p rorm-sql -F postgres
+          cargo test -F tokio-rustls
+          cd rorm-sample
+          RUST_BACKTRACE=full cargo run -- --help
+          echo Config: ${CONFIG_FILE}
+          rm -rvf .models.json
+          rorm-cli migrate --database-config "${CONFIG_FILE}" --log-sql
+          cargo run -F rorm-main
+          rorm-cli make-migrations
+          rorm-cli migrate --database-config "${CONFIG_FILE}" --log-sql
+          RUST_BACKTRACE=full RUST_LOG=rorm=debug cargo run -- "${CONFIG_FILE}"
+
   build-windows:
     name: Build rorm (stable)
     runs-on: [ self-hosted, windows, x64 ]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ D programming language with the name `dorm`.
 
 `rorm` supports the following databases:
 - SQLite 3
-- MariaDB 10.5, 10.6, 10.8 and 10.9
+- MariaDB 10.5 - 10.9
 - Postgres 11 - 15
 
 ## Documentation


### PR DESCRIPTION
- Added a build pipeline for Linux, Windows and MacOS without caching ("build from scratch")
- Fixed clippy SARIF results to use the correct relative paths (prefix `rorm/`)
- Added scripts to convert the result file of `dscanner` to the SARIF file format for Code QL
- Fixed caching issues on Windows (it's still slow, it's Windows)
- Added MariaDB 10.7 to the pipeline (it has End Of Life in Feb 2023)
- Dropped the clippy check from the Windows pipeline (for speed-up and to remove duplication)

Note that CI on Windows and Linux currently still fails due to incompatible changes in the integration tests and (probably) a regression in SQL building for Postgres.